### PR TITLE
chore: Fix for properly detecting if cursor is used as an agent and not a human

### DIFF
--- a/detect_agent/__init__.py
+++ b/detect_agent/__init__.py
@@ -75,10 +75,10 @@ def determine_agent() -> AgentResult:
                 return {"is_agent": True, "agent": {"name": GITHUB_COPILOT}}
             return {"is_agent": True, "agent": {"name": name}}  # type: ignore[return-value]
 
-    if os.environ.get("CURSOR_TRACE_ID"):
+    if os.environ.get("CURSOR_AGENT"):
         return {"is_agent": True, "agent": {"name": CURSOR}}
 
-    if os.environ.get("CURSOR_AGENT"):
+    if os.environ.get("CURSOR_INVOKED_AS") == "agent":
         return {"is_agent": True, "agent": {"name": CURSOR_CLI}}
 
     if os.environ.get("GEMINI_CLI"):


### PR DESCRIPTION
`CURSOR_TRACE_ID` is auto added when using he terminal in cursor. So human usage gets confused as agent usage.

When using the cursor cli they set `CURSOR_INVOKED_AS=agent` and when using composer in cursor it will set `CURSOR_AGENT=1`